### PR TITLE
Enhancement: Add sort attributes to module templates

### DIFF
--- a/templates/access_policies.nac.j2
+++ b/templates/access_policies.nac.j2
@@ -194,7 +194,8 @@
   {% for prov in [pol] | selectattr('children', 'defined')
     | map(attribute='children') | flatten
     | selectattr('dhcpRsProv', 'defined') | map(attribute='dhcpRsProv')
-    | list | default('') %}
+    | list | default('')
+    | sort(attribute='attributes.addr') %}
     {%- set provns.providers = provns.providers + [{
       'ip': prov.attributes.addr,
       'type': 'external_epg' if '/out-' in prov.attributes.tDn else 'epg',

--- a/templates/access_policies.nac.j2
+++ b/templates/access_policies.nac.j2
@@ -194,8 +194,7 @@
   {% for prov in [pol] | selectattr('children', 'defined')
     | map(attribute='children') | flatten
     | selectattr('dhcpRsProv', 'defined') | map(attribute='dhcpRsProv')
-    | list | default('')
-    | sort(attribute='attributes.addr') %}
+    | list | sort(attribute='attributes.addr') | default('') %}
     {%- set provns.providers = provns.providers + [{
       'ip': prov.attributes.addr,
       'type': 'external_epg' if '/out-' in prov.attributes.tDn else 'epg',

--- a/templates/access_policies/aaeps.nac.j2
+++ b/templates/access_policies/aaeps.nac.j2
@@ -35,7 +35,7 @@
     | selectattr('infraRsDomP', 'defined')
     | map(attribute='infraRsDomP')
     | selectattr('attributes.tDn', 'search', '^uni/phys-')
-    | default('') %}
+    | default('') | sort %}
     {%- set physdomns.physical_domains = physdomns.physical_domains + [
       dom.attributes.tDn | replace('uni/phys-', '')
     ] %}
@@ -46,7 +46,7 @@
     | selectattr('infraRsDomP', 'defined')
     | map(attribute='infraRsDomP')
     | selectattr('attributes.tDn', 'search', '^uni/l3dom-')
-    | default('') %}
+    | default('') | sort %}
     {%- set physdomns.physical_domains = physdomns.physical_domains + [
       dom.attributes.tDn | replace('uni/l3dom-', '')
     ] %}
@@ -57,7 +57,7 @@
     | selectattr('infraRsDomP', 'defined')
     | map(attribute='infraRsDomP')
     | selectattr('attributes.tDn', 'search', '^uni/vmmp-VMware/dom-')
-    | default('') %}
+    | default('') | sort %}
     {%- set physdomns.physical_domains = physdomns.physical_domains + [
       dom.attributes.tDn | replace('uni/vmmp-VMware/dom-', '')
     ] %}

--- a/templates/access_policies/aaeps.nac.j2
+++ b/templates/access_policies/aaeps.nac.j2
@@ -35,7 +35,7 @@
     | selectattr('infraRsDomP', 'defined')
     | map(attribute='infraRsDomP')
     | selectattr('attributes.tDn', 'search', '^uni/phys-')
-    | default('') | sort %}
+    | default('') | sort(attribute='attributes.tDn') %}
     {%- set physdomns.physical_domains = physdomns.physical_domains + [
       dom.attributes.tDn | replace('uni/phys-', '')
     ] %}
@@ -46,7 +46,7 @@
     | selectattr('infraRsDomP', 'defined')
     | map(attribute='infraRsDomP')
     | selectattr('attributes.tDn', 'search', '^uni/l3dom-')
-    | default('') | sort %}
+    | default('') | sort(attribute='attributes.tDn') %}
     {%- set physdomns.physical_domains = physdomns.physical_domains + [
       dom.attributes.tDn | replace('uni/l3dom-', '')
     ] %}
@@ -57,7 +57,7 @@
     | selectattr('infraRsDomP', 'defined')
     | map(attribute='infraRsDomP')
     | selectattr('attributes.tDn', 'search', '^uni/vmmp-VMware/dom-')
-    | default('') | sort %}
+    | default('') | sort(attribute='attributes.tDn') %}
     {%- set physdomns.physical_domains = physdomns.physical_domains + [
       dom.attributes.tDn | replace('uni/vmmp-VMware/dom-', '')
     ] %}

--- a/templates/access_policies/netflow.nac.j2
+++ b/templates/access_policies/netflow.nac.j2
@@ -1,6 +1,6 @@
 {%- set nfexpns = namespace(netflow_exporters=[]) %}
 {% for exp in infra_children | selectattr('netflowExporterPol', 'defined')
-  | map(attribute='netflowExporterPol') | list %}
+  | map(attribute='netflowExporterPol') | list | sort(attribute='attributes.name') %}
   {%- set nfexpns.netflow_exporters = nfexpns.netflow_exporters + [{
     'name': exp.attributes.name,
     'description': exp.attributes.descr | default('') | regex_replace('^(.*[:*].*)$', '"\\1"'),
@@ -68,7 +68,7 @@
 
 {%- set nfmonns = namespace(netflow_monitors=[]) %}
 {% for mon in infra_children | selectattr('netflowMonitorPol', 'defined')
-  | map(attribute='netflowMonitorPol') %}
+  | map(attribute='netflowMonitorPol') | sort(attribute='attributes.name') %}
   {%- set nfmonns.netflow_monitors = nfmonns.netflow_monitors + [{
     'name': mon.attributes.name,
     'description': mon.attributes.descr | default('') | regex_replace('^(.*[:*].*)$', '"\\1"'),
@@ -88,7 +88,7 @@
 
 {%- set nfrecns = namespace(netflow_records=[]) %}
 {% for rec in infra_children | selectattr('netflowRecordPol', 'defined')
-  | map(attribute='netflowRecordPol') %}
+  | map(attribute='netflowRecordPol') | sort(attribute='attributes.name') %}
   {%- set nfrecns.netflow_records = nfrecns.netflow_records + [{
     'name': rec.attributes.name,
     'description': rec.attributes.descr | default('') | regex_replace('^(.*[:*].*)$', '"\\1"'),

--- a/templates/access_policies/span.nac.j2
+++ b/templates/access_policies/span.nac.j2
@@ -163,7 +163,7 @@
     | map(attribute='children') | flatten
     | selectattr('spanFilterEntry', 'defined')
     | map(attribute='spanFilterEntry') | default('') 
-    | sort(attribute='attributes.name,attributes.source_ip') %}
+    | sort(attribute='attributes.name,attributes.srcAddr') %}
     {%- set entryns.entries = entryns.entries + [{
       'name': entry.attributes.name | default(''),
       'description': entry.attributes.descr | default('') | regex_replace('^(.*[:*].*)$', '"\\1"'),

--- a/templates/access_policies/span.nac.j2
+++ b/templates/access_policies/span.nac.j2
@@ -3,7 +3,7 @@
 {%- set spandestns = namespace(destination_groups=[]) -%}
 {% for grp in infra_children | selectattr('spanDestGrp', 'defined')
   | map(attribute='spanDestGrp')
-  | default('') %}
+  | default('') | sort(attribute='attributes.name') %}
   {%- set spandestns.destination_groups = spandestns.destination_groups + [{
     'name': grp.attributes.name,
     'description': grp.attributes.descr | default('') | regex_replace('^(.*[:*].*)$', '"\\1"'),
@@ -162,7 +162,8 @@
   {% for entry in [fltr] | selectattr('children', 'defined')
     | map(attribute='children') | flatten
     | selectattr('spanFilterEntry', 'defined')
-    | map(attribute='spanFilterEntry') | default('') %}
+    | map(attribute='spanFilterEntry') | default('') 
+    | sort(attribute='attributes.name,attributes.source_ip') %}
     {%- set entryns.entries = entryns.entries + [{
       'name': entry.attributes.name | default(''),
       'description': entry.attributes.descr | default('') | regex_replace('^(.*[:*].*)$', '"\\1"'),

--- a/templates/fabric_policies.nac.j2
+++ b/templates/fabric_policies.nac.j2
@@ -96,12 +96,13 @@ apic:
 {#- Fabric Scheduler -#}
 {% set schedulerns = namespace(schedulers=[]) %}
 {% for schedule in fabricInst_children | selectattr('trigSchedP', 'defined')
-  | map(attribute='trigSchedP') %}
+  | map(attribute='trigSchedP') | sort(attribute='attributes.name') %}
   {% set recurns = namespace(recurring_windows=[]) %}
   {% for window in [schedule] | selectattr('children', 'defined')
     | map(attribute='children') | flatten
     | selectattr('trigRecurrWindowP', 'defined')
     | map(attribute='trigRecurrWindowP')
+    | sort(attribute='attributes.name')
   %}
   {% set recurns.recurring_windows = recurns.recurring_windows + [{
     'name': window.attributes.name,
@@ -375,7 +376,7 @@ apic:
 {% set fabl2mtuns = namespace(l2_mtu_policies=[]) %}
 {% for policy in fabricInst_children | selectattr('l2InstPol', 'defined')
     | rejectattr('l2InstPol.attributes.name', 'match', 'default')
-    | map(attribute='l2InstPol')%}
+    | map(attribute='l2InstPol') | sort(attribute='attributes.name') %}
     {% set fabl2mtuns.l2_mtu_policies = fabl2mtuns.l2_mtu_policies + [{
       'name': policy.attributes.name,
       'port_mtu_size': policy.attributes.fabricMtu | default('')

--- a/templates/fabric_policies/aaa_users.nac.j2
+++ b/templates/fabric_policies/aaa_users.nac.j2
@@ -1,16 +1,18 @@
 {% set aaausersns = namespace(users=[]) %}
 {% for user in aaaUserEp | selectattr('aaaUser', 'defined')
-  | map(attribute='aaaUser') %}
+  | map(attribute='aaaUser') | sort(attribute='attributes.name') %}
   {% set domainns = namespace(domains=[]) %}
   {% for domain in [user] | selectattr('children', 'defined')
     | map(attribute='children') | flatten
     | selectattr('aaaUserDomain', 'defined')
-    | map(attribute='aaaUserDomain') | default('') %}
+    | map(attribute='aaaUserDomain') | default('')
+    | sort(attribute='attributes.name') %}
     {% set rolesns = namespace(roles=[]) %}
     {% for role in [domain] | selectattr('children', 'defined')
       | map(attribute='children') | flatten
       | selectattr('aaaUserRole', 'defined')
-      | map(attribute='aaaUserRole') %}
+      | map(attribute='aaaUserRole') 
+      | sort(attribute='attributes.name') %}
       {% set rolesns.roles = rolesns.roles + [{
         'name': role.attributes.name,
         'privilege_type': role.attributes.privType | default('')
@@ -26,7 +28,8 @@
   {% for cert in [user] | selectattr('children', 'defined')
     | map(attribute='children') | flatten
     | selectattr('aaaUserCert', 'defined')
-    | map(attribute='aaaUserCert') | default('') %}
+    | map(attribute='aaaUserCert') | default('') 
+    | sort(attribute='attributes.name') %}
     {% set certsns.certificates = certsns.certificates + [{
       'name': cert.attributes.name,
       'data': cert.attributes.data,
@@ -36,7 +39,8 @@
   {% for key in [user] | selectattr('children', 'defined')
     | map(attribute='children') | flatten
     | selectattr('aaaSshAuth', 'defined')
-    | map(attribute='aaaSshAuth') | default('') %}
+    | map(attribute='aaaSshAuth') | default('') 
+    | sort(attribute='attributes.name') %}
     {% set certsns.certificates = certsns.certificates + [{
       'name': key.attributes.name,
       'data': key.attributes.data,

--- a/templates/fabric_policies/fabric_pod_policies.nac.j2
+++ b/templates/fabric_policies/fabric_pod_policies.nac.j2
@@ -10,7 +10,7 @@
     | map(attribute='children') | flatten
     | selectattr('datetimeNtpProv', 'defined')
     | map(attribute='datetimeNtpProv') 
-    | sort(attribute='attributes.hostname_ip') | default([]) %}
+    | sort(attribute='attributes.name') | default([]) %}
     {% set ntpserversns.ntp_servers = ntpserversns.ntp_servers + [{
       'hostname_ip': server.attributes.name,
       'auth_key_id': server.attributes.keyId | default('')

--- a/templates/fabric_policies/fabric_pod_policies.nac.j2
+++ b/templates/fabric_policies/fabric_pod_policies.nac.j2
@@ -9,7 +9,8 @@
   {% for server in [pol] | selectattr('children', 'defined')
     | map(attribute='children') | flatten
     | selectattr('datetimeNtpProv', 'defined')
-    | map(attribute='datetimeNtpProv') | default([]) %}
+    | map(attribute='datetimeNtpProv') 
+    | sort(attribute='attributes.hostname_ip') | default([]) %}
     {% set ntpserversns.ntp_servers = ntpserversns.ntp_servers + [{
       'hostname_ip': server.attributes.name,
       'auth_key_id': server.attributes.keyId | default('')
@@ -29,7 +30,8 @@
   {% for key in [pol] | selectattr('children', 'defined')
     | map(attribute='children') | flatten
     | selectattr('datetimeNtpAuthKey', 'defined')
-    | map(attribute='datetimeNtpAuthKey') | default([])
+    | map(attribute='datetimeNtpAuthKey')
+    | sort(attribute='attributes.id') | default([])
   %}
     {% set ntpkeysns.ntp_keys = ntpkeysns.ntp_keys + [{
       'id': key.attributes.id,

--- a/templates/fabric_policies/management_access_policies.nac.j2
+++ b/templates/fabric_policies/management_access_policies.nac.j2
@@ -1,6 +1,6 @@
 {% set fabmgmtaccns = namespace(management_access_policies=[]) -%}
 {% for policy in fabricInst_children | selectattr('commPol', 'defined')
-  | map(attribute='commPol') | default([]) %}
+  | map(attribute='commPol') | sort(attribute='attributes.name') | default([]) %}
   {% set fabmgmtaccns.management_access_policies = fabmgmtaccns.management_access_policies + [{
     'name': policy.attributes.name,
     'description': policy.attributes.descr | default('') | regex_replace('^(.*[:*].*)$', '"\\1"'),

--- a/templates/fabric_policies/monitoring.nac.j2
+++ b/templates/fabric_policies/monitoring.nac.j2
@@ -7,7 +7,7 @@
     | map(attribute='children') | flatten
     | selectattr('snmpTrapDest', 'defined')
     | map(attribute='snmpTrapDest') 
-    | sort(attribute='attributes.hostname_ip') | default([]) %}
+    | sort(attribute='attributes.host') | default([]) %}
     {% set destns.destinations = destns.destinations + [{
       'hostname_ip': dest.attributes.host,
       'port': dest.attributes.port | default('') | regex_replace('^162$', ''),
@@ -36,7 +36,7 @@
     | map(attribute='children') | flatten
     | selectattr('syslogRemoteDest', 'defined')
     | map(attribute='syslogRemoteDest') 
-    | sort(attribute='attributes.hostname_ip') | default([]) %}
+    | sort(attribute='attributes.host') | default([]) %}
     {% set destns.destinations = destns.destinations + [{
       'hostname_ip': dest.attributes.host,
       'name': dest.attributes.name | default(''),

--- a/templates/fabric_policies/monitoring.nac.j2
+++ b/templates/fabric_policies/monitoring.nac.j2
@@ -1,12 +1,13 @@
 {% set fabmonns = namespace(monitoring={}) -%}
 {% set snmpns = namespace(snmp_traps=[]) %}
 {% for snmptrap in fabricInst_children | selectattr('snmpGroup', 'defined')
-  | map(attribute='snmpGroup') %}
+  | map(attribute='snmpGroup') | sort(attribute='attributes.name') | default([]) %}
   {%- set destns = namespace(destinations=[]) %}
   {% for dest in [snmptrap] | selectattr('children', 'defined')
     | map(attribute='children') | flatten
     | selectattr('snmpTrapDest', 'defined')
-    | map(attribute='snmpTrapDest') | default([]) %}
+    | map(attribute='snmpTrapDest') 
+    | sort(attribute='attributes.hostname_ip') | default([]) %}
     {% set destns.destinations = destns.destinations + [{
       'hostname_ip': dest.attributes.host,
       'port': dest.attributes.port | default('') | regex_replace('^162$', ''),
@@ -29,12 +30,13 @@
 
 {% set syslogns = namespace(syslogs=[]) %}
 {% for syslog in fabricInst_children | selectattr('syslogGroup', 'defined')
-  | map(attribute='syslogGroup') %}
+  | map(attribute='syslogGroup') | sort(attribute='attributes.name') %}
   {%- set destns = namespace(destinations=[]) %}
   {% for dest in [syslog] | selectattr('children', 'defined')
     | map(attribute='children') | flatten
     | selectattr('syslogRemoteDest', 'defined')
-    | map(attribute='syslogRemoteDest') | default([]) %}
+    | map(attribute='syslogRemoteDest') 
+    | sort(attribute='attributes.hostname_ip') | default([]) %}
     {% set destns.destinations = destns.destinations + [{
       'hostname_ip': dest.attributes.host,
       'name': dest.attributes.name | default(''),

--- a/templates/fabric_policies/remote_location.nac.j2
+++ b/templates/fabric_policies/remote_location.nac.j2
@@ -2,7 +2,8 @@
 {% for remote in polUni
   | selectattr('fabricInst', 'defined') | map(attribute='fabricInst')
   | selectattr('children', 'defined') | map(attribute='children') | flatten
-  | selectattr('fileRemotePath', 'defined') | map(attribute='fileRemotePath') %}
+  | selectattr('fileRemotePath', 'defined') | map(attribute='fileRemotePath')
+  | sort(attribute='attributes.name') %}
   {% set fabremotens.remote_locations = fabremotens.remote_locations + [{
     'name': remote.attributes.name,
     'hostname_ip': remote.attributes.host,

--- a/templates/fabric_policies/snmp_pod_policy.nac.j2
+++ b/templates/fabric_policies/snmp_pod_policy.nac.j2
@@ -21,7 +21,7 @@
   {% for fwdr in [policy] | selectattr('children', 'defined')
     | map(attribute='children') | flatten
     | selectattr('snmpTrapFwdServerP', 'defined')
-    | map(attribute='snmpTrapFwdServerP') | sort(attribute='attributes.ip') %}
+    | map(attribute='snmpTrapFwdServerP') | sort(attribute='attributes.addr') %}
     {% set trapfwdns.trap_forwarders = trapfwdns.trap_forwarders + [{
       'ip': fwdr.attributes.addr | default(''),
       'port': fwdr.attributes.port | default('') | regex_replace('^162$', ''),

--- a/templates/fabric_policies/snmp_pod_policy.nac.j2
+++ b/templates/fabric_policies/snmp_pod_policy.nac.j2
@@ -1,10 +1,11 @@
 {%- set snmpns = namespace(snmp_policies=[]) %}
 {%- for policy in fabricInst_children | selectattr('snmpPol', 'defined')
-  | map(attribute='snmpPol') %}
+  | map(attribute='snmpPol') | sort(attribute='attributes.name') %}
   {% set userns = namespace(users=[]) %}
   {%- for user in [policy] | selectattr('children', 'defined')
     | map(attribute='children') | flatten
-    | selectattr('snmpUserP', 'defined') | map(attribute='snmpUserP') %}
+    | selectattr('snmpUserP', 'defined') | map(attribute='snmpUserP') 
+    | sort(attribute='attributes.name') %}
     {% set userns.users = userns.users + [{
       'name': user.attributes.name,
       'description': user.attributes.descr | default('') | regex_replace('^(.*[:*].*)$', '"\\1"'),
@@ -20,7 +21,7 @@
   {% for fwdr in [policy] | selectattr('children', 'defined')
     | map(attribute='children') | flatten
     | selectattr('snmpTrapFwdServerP', 'defined')
-    | map(attribute='snmpTrapFwdServerP') %}
+    | map(attribute='snmpTrapFwdServerP') | sort(attribute='attributes.ip') %}
     {% set trapfwdns.trap_forwarders = trapfwdns.trap_forwarders + [{
       'ip': fwdr.attributes.addr | default(''),
       'port': fwdr.attributes.port | default('') | regex_replace('^162$', ''),
@@ -30,11 +31,11 @@
   {% for client in [policy] | selectattr('children', 'defined')
     | map(attribute='children') | flatten
     | selectattr('snmpClientGrpP', 'defined')
-    | map(attribute='snmpClientGrpP')%}
+    | map(attribute='snmpClientGrpP') | sort(attribute='attributes.name')%}
     {% set entryns = namespace(entries=[]) %}
     {% for entry in [client] | selectattr('children', 'defined')
       | map(attribute='children') | flatten | selectattr('snmpClientP', 'defined')
-      | map(attribute='snmpClientP') %}
+      | map(attribute='snmpClientP') | sort(attribute='attributes.name,attributes.addr')%}
       {% set entryns.entries = entryns.entries + [{
         'name': entry.attributes.name,
         'ip': entry.attributes.addr,

--- a/templates/node_policies.nac.j2
+++ b/templates/node_policies.nac.j2
@@ -131,7 +131,7 @@ apic:
         | selectattr('mgmtRsOoBStNode', 'defined') | selectattr('mgmtRsOoBStNode.attributes.tDn', 'search', 'node-{}$'.format(node.attributes.nodeId))
         | map(attribute='mgmtRsOoBStNode.attributes.addr')
         | first | default(''),
-      'oob_address': polUni | selectattr('fvTenant', 'defined')
+      'oob_gateway': polUni | selectattr('fvTenant', 'defined')
         | selectattr('fvTenant.attributes.name', 'equalto', 'mgmt')
         | map(attribute='fvTenant') | selectattr('children', 'defined')
         | map(attribute='children') | flatten

--- a/templates/pod_policies.nac.j2
+++ b/templates/pod_policies.nac.j2
@@ -18,7 +18,7 @@ apic:
     | selectattr('children', 'defined') | map(attribute='children') | flatten
     | selectattr('fabricExtRoutablePodSubnet', 'defined')
     | map(attribute='fabricExtRoutablePodSubnet')
-    | flatten | list | default([]) %}
+    | flatten | list | sort(attribute='attributes.pool') | default([]) %}
     {% set extteppoolsns.pools = extteppoolsns.pools + [{
       'prefix': pool.attributes.pool | default(''),
       'reserved_address_count': pool.attributes.reserveAddressCount
@@ -31,7 +31,7 @@ apic:
     | selectattr('children', 'defined') | map(attribute='children') | flatten
     | selectattr('fabricExtSetupP', 'defined')
     | map(attribute='fabricExtSetupP')
-    | flatten | list | default([]) %}
+    | flatten | list | sort(attribute='attributes.extPoolId') | default([]) %}
     {% set remotepoolsns.pools = remotepoolsns.pools + [{
       'id': pool.attributes.extPoolId | default(''),
       'remote_pool': pool.attributes.tepPool

--- a/templates/tenant_policies.nac.j2
+++ b/templates/tenant_policies.nac.j2
@@ -7,7 +7,7 @@
   | map(attribute='aaaDomainRef') | flatten | list -%}
 ---
 {%- set _=tenantns.tenant_policies.__setitem__('name', this_tenant.attributes.name) -%}
-{%- set _=tenantns.tenant_policies.__setitem__('description', this_tenant.attributes.description | default('')) -%}
+{%- set _=tenantns.tenant_policies.__setitem__('description', this_tenant.attributes.descr | default('')) -%}
 {%- set _=tenantns.tenant_policies.__setitem__('alias', this_tenant.attributes.nameAlias | default('') ) -%}
 {%- set _=tenantns.tenant_policies.__setitem__('security_domains', this_tenant.children | selectattr('aaaDomainRef', 'defined')
   | map(attribute='aaaDomainRef.attributes.name') | flatten | sort | default('')) -%}
@@ -120,7 +120,7 @@
     {%- set oobsubjns.subjects = oobsubjns.subjects [{
       'name': subj.attributes.name,
       'alias': subj.attributes.nameAlias | default(''),
-      'description': subj.attributes.description | default(''),
+      'description': subj.attributes.descr | default(''),
       'filters': [subj] | selectattr('children', 'defined')
         | map(attribute='children') | flatten
         | selectattr('vzRsSubjFiltAtt', 'defined')
@@ -131,7 +131,7 @@
   {% set oobctns.oob_contracts = oobctns.oob_contracts + [{
     'name': con.attributes.name,
     'alias': con.attributes.nameAlias | default(''),
-    'description': con.attributes.description | default(''),
+    'description': con.attributes.descr | default(''),
     'scope': con.attributes.scope | default('') | replace('context', ''),
     'subjects': oobsubjns.subjects | default(''),
   }] %}

--- a/templates/tenant_policies/bridge_domains.nac.j2
+++ b/templates/tenant_policies/bridge_domains.nac.j2
@@ -5,7 +5,7 @@
       | sort(attribute='attributes.name') %}
   {%- set subnetns = namespace(subnets=[]) -%}
   {% for subnet in bd.children | selectattr('fvSubnet', 'defined')
-    | map(attribute='fvSubnet') %}
+    | map(attribute='fvSubnet') | sort(attribute='attributes.ip') %}
     {%- set subnetns.subnets = subnetns.subnets + [{
       'ip': subnet.attributes.ip,
       'description': subnet.attributes.descr | default('') | regex_replace('^(.*[:*].*)$', '"\\1"'),

--- a/templates/tenant_policies/contracts.nac.j2
+++ b/templates/tenant_policies/contracts.nac.j2
@@ -8,12 +8,12 @@
   {% for subject in [con]
     | selectattr('children', 'defined') | map(attribute='children') | flatten
     | selectattr('vzSubj','defined') | map(attribute='vzSubj')
-    | list | default([]) %}
+    | list | default([]) | sort(attribute='attributes.name') %}
     {% set filterns = namespace(filters=[]) %}
     {% for filter in [subject]
       | selectattr('children', 'defined') | map(attribute='children') | flatten
       | selectattr('vzRsSubjFiltAtt','defined') | map(attribute='vzRsSubjFiltAtt')
-      | list | default([]) %}
+      | list | sort(attribute='attributes.tnVzFilterName') | default([]) %}
       {% set filterns.filters = filterns.filters +
         [{
           'filter': filter.attributes.tnVzFilterName,

--- a/templates/tenant_policies/l3out_node_profiles.nac.j2
+++ b/templates/tenant_policies/l3out_node_profiles.nac.j2
@@ -4,7 +4,7 @@
 {% for np in [l3o]
   | selectattr('children', 'defined') | map(attribute='children') | flatten | list
   | selectattr('l3extLNodeP', 'defined') | map(attribute='l3extLNodeP')
-  | list | default([]) if np %}
+  | list | sort(attribute='attributes.name') | default([]) if np %}
   {%- set bgpns = namespace(bgp={}) %}
   {%- set nodens = namespace(nodes=[]) %}
   {%- set peersns = namespace(peers=[]) -%}
@@ -66,7 +66,8 @@
 
     {% for np in [np]
       | selectattr('children', 'defined') | map(attribute='children')| flatten
-      | selectattr('bgpPeerP', 'defined') | map(attribute='bgpPeerP') %}
+      | selectattr('bgpPeerP', 'defined') | map(attribute='bgpPeerP')
+      | sort(attribute='attributes.addr') %}
       {%- set peerns.peers = peerns.peers + [{
         'ip': np.attributes.addr,
         'description': np.attributes.descr,
@@ -144,7 +145,7 @@
       {% for label in [int_prof] | selectattr('children', 'defined')
         | map(attribute='children') | flatten | list
         | selectattr('dhcpLbl', 'defined') | map(attribute='dhcpLbl')
-        | default([]) %}
+        | sort(attribute='attributes.name') | default([]) %}
         {%- set dhcplabelsns.labels = dhcplabelsns.labels + [{
           'dhcp_relay_policy': label.attributes.name,
           'scope': label.attributes.owner,
@@ -161,13 +162,13 @@
         | map(attribute='children') | flatten | list
         | selectattr('l3extRsPathL3OutAtt', 'defined')
         | map(attribute='l3extRsPathL3OutAtt')
-        | default([]) %}
+        | sort(attribute='attributes.addr') | default([]) %}
         {%- set interfacesns.interfaces = interfacesns.interfaces + [{
           'ip': intf.attributes.addr | replace('0.0.0.0', ''),
           'svi': 'true' if intf.attributes.ifInstT == 'ext-svi' else ''
             | default(''),
           'floating_svi': none,
-          'description': intf.attributes.descr,
+          'description': intf.attributes.descr | default(''),
           'vlan': intf.attributes.encap
             | regex_replace('^vlan-(\d+)$', '\\1') | default(''),
           'autostate': 'true' if intf.attributes.autostate == 'enabled' else '' | default(''),

--- a/templates/tenant_policies/l3outs.nac.j2
+++ b/templates/tenant_policies/l3outs.nac.j2
@@ -171,7 +171,7 @@
   {% for np in [l3o]
     | selectattr('children', 'defined') | map(attribute='children') | flatten | list
     | selectattr('l3extLNodeP', 'defined') | map(attribute='l3extLNodeP')
-    | list | default([]) if np %}
+    | list | sort(attribute='attributes.name') | default([]) if np %}
     {%- set bgpns = namespace(bgp={}) %}
     {%- set nodens = namespace(nodes=[]) %}
     {%- set peersns = namespace(peers=[]) -%}
@@ -328,7 +328,7 @@
       {% for label in [int_prof] | selectattr('children', 'defined')
         | map(attribute='children') | flatten | list
         | selectattr('dhcpLbl', 'defined') | map(attribute='dhcpLbl')
-        | default([]) %}
+        | sort(attribute='attributes.name') | default([]) %}
         {%- set dhcplabelsns.labels = dhcplabelsns.labels + [{
           'dhcp_relay_policy': label.attributes.name,
           'scope': label.attributes.owner,
@@ -353,14 +353,14 @@
       %}
       {#- Floating SVI Interface -#}
       {#- Physical Interface -#}
-      {% for intf in interface_profiles %}
+      {% for intf in interface_profiles | sort(attribute='attributes.ip') %}
         {#- Set Interface Paths -#}
         {%- set interfacepathsns = namespace(paths=[]) %}
         {% for path in [intf] | selectattr('children', 'defined')
           | map(attribute='children' ) | flatten
           | selectattr('l3extRsDynPathAtt', 'defined')
           | map(attribute='l3extRsDynPathAtt')
-          | list | default('') %}
+          | list | sort(attribute='attributes.floatingAddr') | default('') %}
           {%- set interfacepathsns.paths = interfacepathsns.paths + [{
             'floating_ip': path.attributes.floatingAddr,
             'physical_domain': path.attributes.tDn

--- a/templates/tenant_policies/l3outs.nac.j2
+++ b/templates/tenant_policies/l3outs.nac.j2
@@ -353,7 +353,7 @@
       %}
       {#- Floating SVI Interface -#}
       {#- Physical Interface -#}
-      {% for intf in interface_profiles | sort(attribute='attributes.ip') %}
+      {% for intf in interface_profiles | sort(attribute='attributes.addr') %}
         {#- Set Interface Paths -#}
         {%- set interfacepathsns = namespace(paths=[]) %}
         {% for path in [intf] | selectattr('children', 'defined')

--- a/templates/tenant_policies/sr_mpls_l3outs.nac.j2
+++ b/templates/tenant_policies/sr_mpls_l3outs.nac.j2
@@ -116,7 +116,7 @@
           | map(attribute='children' ) | flatten
           | selectattr('l3extRsDynPathAtt', 'defined')
           | map(attribute='l3extRsDynPathAtt')
-          | list | default('') %}
+          | list | default('') | sort(attribute='attributes.floatingAddr') %}
           {%- set interfacepathsns.paths = interfacepathsns.paths + [{
             'floating_ip': path.attributes.floatingAddr,
             'physical_domain': path.attributes.tDn
@@ -345,7 +345,7 @@
   {% for eepg in [l3o] | selectattr('children', 'defined')
     | map(attribute='children') | flatten
     | selectattr('l3extInstP', 'defined') | map(attribute='l3extInstP')
-    | default('') %}
+    | default('') | sort(attribute='attributes.name') %}
     {%- set eepgsubnetns = namespace(subnets=[])%}
     {% for subnet in [eepg] | selectattr('children', 'defined')
       | map(attribute='children') | flatten
@@ -410,7 +410,7 @@
       | selectattr('l3extRsLblToInstP', 'defined')
       | map(attribute='l3extRsLblToInstP')
       | map(attribute='attributes.tDn')
-      | default([]) %}
+      | sort | default([]) %}
       {%- set srmpl3_infra_eepgns.eepgs = srmpl3_infra_eepgns.eepgs + [
         infra_eepg | regex_replace('^(.*?)\/instP-(.*)$', '\\2')
       ] %}

--- a/templates/tenant_policies/vrfs.nac.j2
+++ b/templates/tenant_policies/vrfs.nac.j2
@@ -8,12 +8,13 @@
     | selectattr('children', 'defined') | map(attribute='children') | flatten
     | selectattr('leakInternalSubnet', 'defined')
     | map(attribute='leakInternalSubnet')
-    | default([]) %}
+    | default([]) | sort(attribute='attributes.ip') %}
     {%- set pfxdestsns = namespace(dests=[]) %}
     {% for dest in [prefix] | selectattr('children', 'defined')
       | map(attribute='children') | flatten
       | selectattr('leakTo', 'defined') | map(attribute='leakTo')
-      | default([]) %}
+      | default([])
+      | sort(attribute='attributes.tenantName, attributes.ctxName') %}
       {%- set pfxdestsns.dests = pfxdestsns.dests + [{
         'tenant': dest.attributes.tenantName,
         'vrf': dest.attributes.ctxName,
@@ -37,12 +38,12 @@
     | selectattr('children', 'defined') | map(attribute='children') | flatten
     | selectattr('leakExternalSubnet', 'defined')
     | map(attribute='leakExternalSubnet')
-    | default([]) %}
+    | sort(attribute='attributes.ip') | default([]) %}
     {%- set pfxdestsns = namespace(dests=[]) %}
     {% for dest in [prefix] | selectattr('children', 'defined')
       | map(attribute='children') | flatten
       | selectattr('leakTo', 'defined') | map(attribute='leakTo')
-      | default([]) %}
+      | sort(attribute='attributes.tenantName,attributes.ctxName') | default([]) %}
       {%- set pfxdestsns.dests = pfxdestsns.dests + [{
         'tenant': dest.attributes.tenantName,
         'vrf': dest.attributes.ctxName,
@@ -165,7 +166,7 @@
       | map(attribute='pimStaticRPPol') | selectattr('children', 'defined')
       | map(attribute='children') | flatten
       | selectattr('pimStaticRPEntryPol', 'defined') | map(attribute='pimStaticRPEntryPol')
-      | flatten | list |default([]) %}
+      | flatten | list | sort(attribute='attributes.rpIp') | default([]) %}
       {%- set staticrpns.static_rps = staticrpns.static_rps + [{
         'ip': rp.attributes.rpIp,
         'multicast_route_map': [rp]
@@ -183,7 +184,7 @@
       | map(attribute='pimFabricRPPol')
       | selectattr('children', 'defined') | map(attribute='children') | flatten
       | selectattr('pimStaticRPEntryPol', 'defined') | map(attribute='pimStaticRPEntryPol')
-      | flatten | default([]) %}
+      | flatten | sort(attribute='attributes.rpIp') | default([]) %}
       {%- set fabricrpns.fabric_rps = fabricrpns.fabric_rps + [{
         'ip': rp.attributes.rpIp,
         'multicast_route_map': [rp]
@@ -201,7 +202,7 @@
       | map(attribute='igmpCtxP') | selectattr('children', 'defined')
       | map(attribute='children') | flatten
       | selectattr('igmpSSMXlateP', 'defined') | map(attribute='igmpSSMXlateP')
-      | list %}
+      | sort(attribute='attributes.grpPfx') | list %}
       {%- set igmpxlatens.policies = igmpxlatens.policies + [{
         'group_prefix': pol.attributes.grpPfx,
         'source_address': pol.attributes.srcAddr,
@@ -213,7 +214,7 @@
       | map(attribute='pimInterVRFPol') | selectattr('children', 'defined')
       | map(attribute='children') | flatten
       | selectattr('pimInterVRFEntryPol', 'defined') | map(attribute='pimInterVRFEntryPol')
-      | flatten | list | default([]) %}
+      | flatten | list | sort(attribute='attributes.srcVrfDn') | default([]) %}
     {%- set intervrfpolns.policies = intervrfpolns.policies + [{
       'tenant': pol.attributes.srcVrfDn | regex_replace('^.*tn-(.*?)/ctx-(.*?)$', '\\1'),
       'vrf': pol.attributes.srcVrfDn | regex_replace('^.*tn-(.*?)/ctx-(.*?)$', '\\2'),


### PR DESCRIPTION
Some jinja for loops did not have a sort filter applied so resulting lists of items were not in a predictable order.